### PR TITLE
reference models with support for dependency namespacing

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -2,7 +2,7 @@
 #config other dbt settings within ~/.dbt/profiles.yml
 package:
   name: 'Analyst_Collective'
-  version: 1.0
+  version: '1.0'
 
 source-paths: ["models"]
 target-path: "target"

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,8 +1,7 @@
 #settings specifically for this models directory
 #config other dbt settings within ~/.dbt/profiles.yml
-package:
-  name: 'Analyst_Collective'
-  version: '1.0'
+name: 'Analyst_Collective'
+version: '1.0'
 
 source-paths: ["models"]
 target-path: "target"

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,5 +1,9 @@
 #settings specifically for this models directory
 #config other dbt settings within ~/.dbt/profiles.yml
+package:
+  name: 'Analyst_Collective'
+  version: 1.0
+
 source-paths: ["models"]
 target-path: "target"
 clean-targets: ["target"]

--- a/models/email/emails_denormalized.sql
+++ b/models/email/emails_denormalized.sql
@@ -1,6 +1,6 @@
 with events as (
 
-  select * from {{env.schema}}.pardot_emails
+  select * from {{load('pardot_emails')}}
 
 ),
 

--- a/models/email/emails_denormalized.sql
+++ b/models/email/emails_denormalized.sql
@@ -1,6 +1,6 @@
 with events as (
 
-  select * from {{load('pardot_emails')}}
+  select * from {{ref('pardot_emails')}}
 
 ),
 

--- a/models/mailchimp/mailchimp_all_events.sql
+++ b/models/mailchimp/mailchimp_all_events.sql
@@ -1,34 +1,34 @@
 with 
 sends as (
     select campaign_id, email_id, 'sent' as event_action, sent_date as event_date
-    from {{load('mailchimp_sends')}}
+    from {{ref('mailchimp_sends')}}
 ),
 
 soft_bounces as (
     select campaign_id, email_id, 'soft bounce' as event_action, bounced_date as event_date
-    from {{load('mailchimp_bounces')}}
+    from {{ref('mailchimp_bounces')}}
     where bounce_type = 'soft'
 ),
 
 hard_bounces as (
     select campaign_id, email_id, 'hard bounce' as event_action, bounced_date as event_date
-    from {{load('mailchimp_bounces')}}
+    from {{ref('mailchimp_bounces')}}
     where bounce_type = 'hard'
 ),
 
 opens as (
     select campaign_id, email_id, 'opened' as event_action, opened_date as event_date
-    from {{load('mailchimp_opens')}}
+    from {{ref('mailchimp_opens')}}
 ),
 
 clicks as (
     select campaign_id, email_id, 'clicked' as event_action, clicked_date as event_date
-    from {{load('mailchimp_clicks')}}
+    from {{ref('mailchimp_clicks')}}
 ),
 
 unsubscribes as (
     select campaign_id, email_id, 'unsubscribed' as event_action, unsubscribed_date as event_date
-    from {{load('mailchimp_unsubscribes')}}
+    from {{ref('mailchimp_unsubscribes')}}
 )
 
 select *

--- a/models/mailchimp/mailchimp_all_events.sql
+++ b/models/mailchimp/mailchimp_all_events.sql
@@ -1,34 +1,34 @@
 with 
 sends as (
     select campaign_id, email_id, 'sent' as event_action, sent_date as event_date
-    from {{env.schema}}.mailchimp_sends
+    from {{load('mailchimp_sends')}}
 ),
 
 soft_bounces as (
     select campaign_id, email_id, 'soft bounce' as event_action, bounced_date as event_date
-    from {{env.schema}}.mailchimp_bounces
+    from {{load('mailchimp_bounces')}}
     where bounce_type = 'soft'
 ),
 
 hard_bounces as (
     select campaign_id, email_id, 'hard bounce' as event_action, bounced_date as event_date
-    from {{env.schema}}.mailchimp_bounces
+    from {{load('mailchimp_bounces')}}
     where bounce_type = 'hard'
 ),
 
 opens as (
     select campaign_id, email_id, 'opened' as event_action, opened_date as event_date
-    from {{env.schema}}.mailchimp_opens
+    from {{load('mailchimp_opens')}}
 ),
 
 clicks as (
     select campaign_id, email_id, 'clicked' as event_action, clicked_date as event_date
-    from {{env.schema}}.mailchimp_clicks
+    from {{load('mailchimp_clicks')}}
 ),
 
 unsubscribes as (
     select campaign_id, email_id, 'unsubscribed' as event_action, unsubscribed_date as event_date
-    from {{env.schema}}.mailchimp_unsubscribes
+    from {{load('mailchimp_unsubscribes')}}
 )
 
 select *

--- a/models/mailchimp/mailchimp_bounces.sql
+++ b/models/mailchimp/mailchimp_bounces.sql
@@ -1,6 +1,6 @@
 select a.campaign_id, a.email_id, action_date as bounced_date, status as bounce_type
-from {{env.schema}}.mailchimp_email_actions a
-inner join {{env.schema}}.mailchimp_sent_to b
+from {{load('mailchimp_email_actions')}} a
+inner join {{load('mailchimp_sent_to')}} b
 	on a.campaign_id = b.campaign_id
 	and a.email_id = b.email_id
 where action = 'bounce'

--- a/models/mailchimp/mailchimp_bounces.sql
+++ b/models/mailchimp/mailchimp_bounces.sql
@@ -1,6 +1,6 @@
 select a.campaign_id, a.email_id, action_date as bounced_date, status as bounce_type
-from {{load('mailchimp_email_actions')}} a
-inner join {{load('mailchimp_sent_to')}} b
+from {{ref('mailchimp_email_actions')}} a
+inner join {{ref('mailchimp_sent_to')}} b
 	on a.campaign_id = b.campaign_id
 	and a.email_id = b.email_id
 where action = 'bounce'

--- a/models/mailchimp/mailchimp_clicks.sql
+++ b/models/mailchimp/mailchimp_clicks.sql
@@ -1,3 +1,3 @@
 select campaign_id, email_id, action_date as clicked_date
-from {{load('mailchimp_email_actions')}}
+from {{ref('mailchimp_email_actions')}}
 where action = 'click'

--- a/models/mailchimp/mailchimp_clicks.sql
+++ b/models/mailchimp/mailchimp_clicks.sql
@@ -1,3 +1,3 @@
 select campaign_id, email_id, action_date as clicked_date
-from {{env.schema}}.mailchimp_email_actions
+from {{load('mailchimp_email_actions')}}
 where action = 'click'

--- a/models/mailchimp/mailchimp_email_summary.sql
+++ b/models/mailchimp/mailchimp_email_summary.sql
@@ -1,12 +1,12 @@
 with
 sends as (
     select campaign_id, email_id, sent_date
-    from {{env.schema}}.mailchimp_sends
+    from {{load('mailchimp_sends')}}
 ),
 
 hard_bounces as (
     select campaign_id, email_id, min(bounced_date) as hard_bounced_date
-    from {{env.schema}}.mailchimp_bounces
+    from {{load('mailchimp_bounces')}}
     where bounce_type = 'hard'
     group by campaign_id, email_id
 ),
@@ -15,7 +15,7 @@ opens as (
     select
         campaign_id, email_id, min(opened_date) as first_opened_date,
         max(opened_date) as last_opened_date, count(*) as total_opens
-    from {{env.schema}}.mailchimp_opens
+    from {{load('mailchimp_opens')}}
     group by campaign_id, email_id
 ),
 
@@ -23,13 +23,13 @@ clicks as (
     select
         campaign_id, email_id, min(clicked_date) as first_clicked_date,
         max(clicked_date) as last_clicked_date, count(*) as total_clicks
-    from {{env.schema}}.mailchimp_clicks
+    from {{load('mailchimp_clicks')}}
     group by campaign_id, email_id
 ),
 
 unsubscribes as (
     select campaign_id, email_id, unsubscribed_date
-    from {{env.schema}}.mailchimp_unsubscribes
+    from {{load('mailchimp_unsubscribes')}}
 )
 
 select

--- a/models/mailchimp/mailchimp_email_summary.sql
+++ b/models/mailchimp/mailchimp_email_summary.sql
@@ -1,12 +1,12 @@
 with
 sends as (
     select campaign_id, email_id, sent_date
-    from {{load('mailchimp_sends')}}
+    from {{ref('mailchimp_sends')}}
 ),
 
 hard_bounces as (
     select campaign_id, email_id, min(bounced_date) as hard_bounced_date
-    from {{load('mailchimp_bounces')}}
+    from {{ref('mailchimp_bounces')}}
     where bounce_type = 'hard'
     group by campaign_id, email_id
 ),
@@ -15,7 +15,7 @@ opens as (
     select
         campaign_id, email_id, min(opened_date) as first_opened_date,
         max(opened_date) as last_opened_date, count(*) as total_opens
-    from {{load('mailchimp_opens')}}
+    from {{ref('mailchimp_opens')}}
     group by campaign_id, email_id
 ),
 
@@ -23,13 +23,13 @@ clicks as (
     select
         campaign_id, email_id, min(clicked_date) as first_clicked_date,
         max(clicked_date) as last_clicked_date, count(*) as total_clicks
-    from {{load('mailchimp_clicks')}}
+    from {{ref('mailchimp_clicks')}}
     group by campaign_id, email_id
 ),
 
 unsubscribes as (
     select campaign_id, email_id, unsubscribed_date
-    from {{load('mailchimp_unsubscribes')}}
+    from {{ref('mailchimp_unsubscribes')}}
 )
 
 select

--- a/models/mailchimp/mailchimp_opens.sql
+++ b/models/mailchimp/mailchimp_opens.sql
@@ -1,3 +1,3 @@
 select campaign_id, email_id, action_date as opened_date
-from {{env.schema}}.mailchimp_email_actions
+from {{load('mailchimp_email_actions')}}
 where action = 'open'

--- a/models/mailchimp/mailchimp_opens.sql
+++ b/models/mailchimp/mailchimp_opens.sql
@@ -1,3 +1,3 @@
 select campaign_id, email_id, action_date as opened_date
-from {{load('mailchimp_email_actions')}}
+from {{ref('mailchimp_email_actions')}}
 where action = 'open'

--- a/models/mailchimp/mailchimp_sends.sql
+++ b/models/mailchimp/mailchimp_sends.sql
@@ -1,6 +1,6 @@
 select a.campaign_id, a.email_id, sent_date
-from {{env.schema}}.mailchimp_sent_to a
+from {{load('mailchimp_sent_to')}} a
 -- add information about when the campaign was sent
-inner join {{env.schema}}.mailchimp_campaigns b
+inner join {{load('mailchimp_campaigns')}} b
 	on a.campaign_id = b.campaign_id
 	and a.list_id = b.list_id

--- a/models/mailchimp/mailchimp_sends.sql
+++ b/models/mailchimp/mailchimp_sends.sql
@@ -1,6 +1,6 @@
 select a.campaign_id, a.email_id, sent_date
-from {{load('mailchimp_sent_to')}} a
+from {{ref('mailchimp_sent_to')}} a
 -- add information about when the campaign was sent
-inner join {{load('mailchimp_campaigns')}} b
+inner join {{ref('mailchimp_campaigns')}} b
 	on a.campaign_id = b.campaign_id
 	and a.list_id = b.list_id

--- a/models/pardot/pardot_emails.sql
+++ b/models/pardot/pardot_emails.sql
@@ -5,5 +5,5 @@ data necessary to conform to the extended interface.
 */
 
 select "@timestamp", "@event", "@user_id", email_id as "@email_id", details as "@subject"
-	from {{load('pardot_visitoractivity')}}
+	from {{ref('pardot_visitoractivity')}}
 where "@event" in ('email sent', 'email opened', 'email click')

--- a/models/pardot/pardot_emails.sql
+++ b/models/pardot/pardot_emails.sql
@@ -5,5 +5,5 @@ data necessary to conform to the extended interface.
 */
 
 select "@timestamp", "@event", "@user_id", email_id as "@email_id", details as "@subject"
-	from {{env.schema}}.pardot_visitoractivity
+	from {{load('pardot_visitoractivity')}}
 where "@event" in ('email sent', 'email opened', 'email click')

--- a/models/pardot/pardot_tests.sql
+++ b/models/pardot/pardot_tests.sql
@@ -2,7 +2,7 @@ select
 	'visitoractivity_fresher_than_one_day' as name,
 	'Most recent visitoractivity entry is no more than one day old' as description,
 	max("@timestamp"::timestamp) > current_date - '1 day'::interval as result
-from {{load('pardot_visitoractivity')}}
+from {{ref('pardot_visitoractivity')}}
 
 
 

--- a/models/pardot/pardot_tests.sql
+++ b/models/pardot/pardot_tests.sql
@@ -2,7 +2,7 @@ select
 	'visitoractivity_fresher_than_one_day' as name,
 	'Most recent visitoractivity entry is no more than one day old' as description,
 	max("@timestamp"::timestamp) > current_date - '1 day'::interval as result
-from {{env.schema}}.pardot_visitoractivity
+from {{load('pardot_visitoractivity')}}
 
 
 

--- a/models/pardot/pardot_visitoractivity.sql
+++ b/models/pardot/pardot_visitoractivity.sql
@@ -9,7 +9,7 @@ select
 	va.*
 from
 	olga_pardot.visitoractivity va
-	inner join {{env.schema}}.pardot_visitoractivity_events_meta e
+	inner join {{load('pardot_visitoractivity_events_meta')}} e
 		on va."type" = e."type" and va.type_name = e.type_name
-	inner join {{env.schema}}.pardot_visitoractivity_types_meta t
+	inner join {{load('pardot_visitoractivity_types_meta')}} t
 		on va."type" = t."type"

--- a/models/pardot/pardot_visitoractivity.sql
+++ b/models/pardot/pardot_visitoractivity.sql
@@ -9,7 +9,7 @@ select
 	va.*
 from
 	olga_pardot.visitoractivity va
-	inner join {{load('pardot_visitoractivity_events_meta')}} e
+	inner join {{ref('pardot_visitoractivity_events_meta')}} e
 		on va."type" = e."type" and va.type_name = e.type_name
-	inner join {{load('pardot_visitoractivity_types_meta')}} t
+	inner join {{ref('pardot_visitoractivity_types_meta')}} t
 		on va."type" = t."type"

--- a/models/stripe/stripe_invoices_cleaned.sql
+++ b/models/stripe/stripe_invoices_cleaned.sql
@@ -9,6 +9,6 @@ select
   timestamp 'epoch' + period_start * interval '1 Second' as period_start,
   timestamp 'epoch' + period_end * interval '1 Second' as period_end
 from
-  {{load('stripe_invoices')}}
+  {{ref('stripe_invoices')}}
 
 

--- a/models/stripe/stripe_invoices_cleaned.sql
+++ b/models/stripe/stripe_invoices_cleaned.sql
@@ -9,6 +9,6 @@ select
   timestamp 'epoch' + period_start * interval '1 Second' as period_start,
   timestamp 'epoch' + period_end * interval '1 Second' as period_end
 from
-  {{env.schema}}.stripe_invoices
+  {{load('stripe_invoices')}}
 
 

--- a/models/stripe/stripe_invoices_transformed.sql
+++ b/models/stripe/stripe_invoices_transformed.sql
@@ -2,7 +2,7 @@
 with invoices as (
 
   select *
-  from {{env.schema}}.stripe_invoices_cleaned
+  from {{load('stripe_invoices_cleaned')}}
   where paid is true
     and forgiven is false
 
@@ -55,7 +55,7 @@ from customer_dates d
     on d.date_month >= date_trunc('month', i.period_start)
     and d.date_month < date_trunc('month', i.period_end)
     and d.customer = i.customer
-  left outer join {{env.schema}}.stripe_subscriptions s on i.subscription_id = s.id
-  left outer join {{env.schema}}.stripe_plans p on s.plan_id = p.id
+  left outer join {{load('stripe_subscriptions')}} s on i.subscription_id = s.id
+  left outer join {{load('stripe_plans')}} p on s.plan_id = p.id
 
 

--- a/models/stripe/stripe_invoices_transformed.sql
+++ b/models/stripe/stripe_invoices_transformed.sql
@@ -2,7 +2,7 @@
 with invoices as (
 
   select *
-  from {{load('stripe_invoices_cleaned')}}
+  from {{ref('stripe_invoices_cleaned')}}
   where paid is true
     and forgiven is false
 
@@ -55,7 +55,7 @@ from customer_dates d
     on d.date_month >= date_trunc('month', i.period_start)
     and d.date_month < date_trunc('month', i.period_end)
     and d.customer = i.customer
-  left outer join {{load('stripe_subscriptions')}} s on i.subscription_id = s.id
-  left outer join {{load('stripe_plans')}} p on s.plan_id = p.id
+  left outer join {{ref('stripe_subscriptions')}} s on i.subscription_id = s.id
+  left outer join {{ref('stripe_plans')}} p on s.plan_id = p.id
 
 

--- a/models/trello/trello_model_tests.sql
+++ b/models/trello/trello_model_tests.sql
@@ -1,7 +1,7 @@
 with null_boards_or_lists as
 (
   select id
-    from {{load('trello_card_location')}}
+    from {{ref('trello_card_location')}}
   where
   data__board__id is null
     or data__list__id is null
@@ -18,4 +18,4 @@ select
   'fresher_than_one_day',
   'Most recent entry is no more than one day old',
 max(date::timestamp) > current_date - '1 day'::interval
-from {{load('trello_card_location')}}
+from {{ref('trello_card_location')}}

--- a/models/trello/trello_model_tests.sql
+++ b/models/trello/trello_model_tests.sql
@@ -1,7 +1,7 @@
 with null_boards_or_lists as
 (
   select id
-    from {{env.schema}}.trello_card_location
+    from {{load('trello_card_location')}}
   where
   data__board__id is null
     or data__list__id is null
@@ -18,4 +18,4 @@ select
   'fresher_than_one_day',
   'Most recent entry is no more than one day old',
 max(date::timestamp) > current_date - '1 day'::interval
-from {{env.schema}}.trello_card_location
+from {{load('trello_card_location')}}

--- a/models/zuora/zuora_subscriptions_w_charges_and_amendments.sql
+++ b/models/zuora/zuora_subscriptions_w_charges_and_amendments.sql
@@ -5,11 +5,11 @@ with subscr_w_amendments as
         account_number, acc.account_id, sub.subscr_id,
         subscr_name, subscr_status, subscr_term_type, 
         subscr_start, subscr_end, subscr_version, amend_id, amend_start
-    from {{load('zuora_account')}} acc
-    inner join {{load('zuora_subscription')}} sub
+    from {{ref('zuora_account')}} acc
+    inner join {{ref('zuora_subscription')}} sub
         on acc.account_id = sub.account_id
     -- add ammendments
-    left outer join {{load('zuora_amendment')}} amend
+    left outer join {{ref('zuora_amendment')}} amend
         on sub.subscr_id = amend.subscr_id
 )
 
@@ -21,7 +21,7 @@ select
     min(subscr_start) over() as first_subscr,
     "@mrr" as mrr
 from subscr_w_amendments sub
-inner join {{load('zuora_rate_plan')}} rp
+inner join {{ref('zuora_rate_plan')}} rp
     on rp.subscr_id = sub.subscr_id
-inner join {{load('zuora_rate_plan_charge')}} rpc
+inner join {{ref('zuora_rate_plan_charge')}} rpc
     on rpc.rate_plan_id = rp.rate_plan_id

--- a/models/zuora/zuora_subscriptions_w_charges_and_amendments.sql
+++ b/models/zuora/zuora_subscriptions_w_charges_and_amendments.sql
@@ -5,11 +5,11 @@ with subscr_w_amendments as
         account_number, acc.account_id, sub.subscr_id,
         subscr_name, subscr_status, subscr_term_type, 
         subscr_start, subscr_end, subscr_version, amend_id, amend_start
-    from {{env.schema}}.zuora_account acc
-    inner join {{env.schema}}.zuora_subscription sub
+    from {{load('zuora_account')}} acc
+    inner join {{load('zuora_subscription')}} sub
         on acc.account_id = sub.account_id
     -- add ammendments
-    left outer join {{env.schema}}.zuora_amendment amend
+    left outer join {{load('zuora_amendment')}} amend
         on sub.subscr_id = amend.subscr_id
 )
 
@@ -21,7 +21,7 @@ select
     min(subscr_start) over() as first_subscr,
     "@mrr" as mrr
 from subscr_w_amendments sub
-inner join {{env.schema}}.zuora_rate_plan rp
+inner join {{load('zuora_rate_plan')}} rp
     on rp.subscr_id = sub.subscr_id
-inner join {{env.schema}}.zuora_rate_plan_charge rpc
+inner join {{load('zuora_rate_plan_charge')}} rpc
     on rpc.rate_plan_id = rp.rate_plan_id


### PR DESCRIPTION
At the present time, there is one monolithic Analyst Collective repository. In the future, there will be a rich ecosystem of open source analytical models. In this new world, it will be useful to fully specify a model in a way which is decoupled from the name of the resulting table in Redshift.

``` sql
-- before
SELECT * from {{ env.schema }}.pardot_visitor_activity;
-- now
SELECT * from {{ ref('pardot_visitor_activity') }};
-- future?
SELECT * from {{ ref('analyst_collective_package', 'pardot_visitor_activity') }};
```

Tested by cleaning the target dir, compiling sql, and running the resulting code. It works!
This should be merged at the same time as https://github.com/analyst-collective/dbt
